### PR TITLE
Clean exit from demo and ADC thread

### DIFF
--- a/demos/high_res/adc.c
+++ b/demos/high_res/adc.c
@@ -184,6 +184,11 @@ int mqtt_temp_pub_init(){
 
 int *adc_init(lv_demo_high_res_api_t * api)
 {
+	if (access("/sys/bus/iio/devices/iio\:device0/in_voltage0_raw", F_OK)) {
+		printf("ADC does not exist\n");
+		pthread_exit(0);
+	}
+
 	api_hmi = api;
     mqtt_temp_pub_init();
 	char line[16];

--- a/demos/high_res/lv_demo_high_res.h
+++ b/demos/high_res/lv_demo_high_res.h
@@ -87,7 +87,7 @@ typedef struct {
     void * user_data; /* optional extra data field for the user to use freely */
 } lv_demo_high_res_api_t;
 
-typedef void (*lv_demo_high_res_exit_cb_t)(lv_demo_high_res_api_t * api);
+typedef void (*lv_demo_high_res_exit_cb_t)(int);
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/demos/high_res/lv_demo_high_res_top_margin.c
+++ b/demos/high_res/lv_demo_high_res_top_margin.c
@@ -7,6 +7,7 @@
  *      INCLUDES
  *********************/
 
+#include <signal.h>
 #include "lv_demo_high_res_private.h"
 #if LV_USE_DEMO_HIGH_RES
 
@@ -146,7 +147,7 @@ void lv_demo_high_res_top_margin_deinit_subjects(lv_demo_high_res_ctx_t * c)
 static void logout_cb(lv_event_t * e)
 {
     lv_demo_high_res_ctx_t * c = lv_event_get_user_data(e);
-    if(c->exit_cb) c->exit_cb(&c->api);
+    if(c->exit_cb) c->exit_cb(SIGTERM);
 }
 
 static lv_obj_t * create_icon(lv_obj_t * parent, lv_subject_t * subject, lv_image_dsc_t ** img_dsc_pair,


### PR DESCRIPTION
These are some small fixes addressing issues such as:
1. ADC thread continuing to try to access the ADC sysfs entry even when it doesn't exist
2. The screen not being cleared in response to Crtl-C, `kill` and `systemctl stop ...`

Tested these changes on AM62L with RPi touch display.